### PR TITLE
Optimize balance algorithm, fix bugs

### DIFF
--- a/ZenID.py
+++ b/ZenID.py
@@ -593,10 +593,7 @@ class ZenIDCombineFace:
         if face_embed_2 is None:
             raise Exception('Reference Image: No face detected.')
 
-        if balance < 0.5:
-            face_embed = face_embed_1 * (1 - balance) + face_embed_2 * balance
-        else:
-            face_embed = face_embed_2 * (1 - balance) + face_embed_1 * balance
+        face_embed = face_embed_2 * (1 - balance) + face_embed_1 * balance
 
         ratio = 8.0
         dst = arcface_dst * ratio


### PR DESCRIPTION
This PR optimizes the balance algorithm as detailed below:
1. I tested the case of balance of 0.1 and 0.9, and found that the fused graph features are inclined to image1.
2. So I looked up the source code and found that the algorithm is as follows:
```python
if balance < 0.5:
    face_embed = face_embed_1 * (1 - balance) + face_embed_2 * balance
else: 
    face_embed = face_embed_2 * (1 - balance) + face_embed_1 * balance
```
Then we use the nesting method to reproduce the vulnerability, which goes to the if branch when balance = 0.1:
`face_embed = face_embed_1 * 0.9 + face_embed_2 * 0.1`
At this point it can be concluded that face_embed_1 has the largest weight.

Next, let's look at the case of BALANCE = 0.9:
`face_embed = face_embed_2 * 0.1 + face_embed_1 * 0.9`
It can be noticed that it is still face_embed_1 that has the largest weight.

Therefore, I think this way of writing is slightly problematic, I changed the algorithm to the following (no need to distinguish if/else):
`face_embed = face_embed_2 * (1 - balance) + face_embed_1 * balance`

This would be consistent with image1 being weighted higher when the balance value tends to 1, and vice versa for image2.
Please review this change in your busy schedule, and feel free to contact us if you have any questions~!
Finally, thank you for contributing to the ComfyUI open source community!